### PR TITLE
add controllerAs:'$ctrl' in component snippet

### DIFF
--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -88,6 +88,7 @@
 			"\t\t\ttemplate:'${htmlTemplate}',",
 			"\t\t\t//templateUrl: '${templateUrl}',",
 			"\t\t\tcontroller: ${Controller}Controller,",
+			"\t\t\tcontrollerAs: '$ctrl',",
 			"\t\t\tbindings: {",
 			"\t\t\t\t${Binding}: '=',",
 			"\t\t\t},",


### PR DESCRIPTION
since $ctrl is a placeholder right now in component snippet, i suggest  adding controllerAs:'$ctrl'  such that if user decided to change $ctrl to vm for example it will keep working as excepected